### PR TITLE
スクリーンエディタの更新

### DIFF
--- a/usr/sedit/GNUmakefile
+++ b/usr/sedit/GNUmakefile
@@ -33,7 +33,7 @@ SRCS=${NAME}.cmm buffer.cmm screen.cmm
 all : clean ${NAME}.exe # ${NAME}
 
 ${NAME}.exe : ${SRCS}
-	cm2e -o ${NAME} ${SRCS}
+	cm2e -o ${NAME} -s 14000 ${SRCS}
 
 ${NAME} : ${SRCS}
 	cm2c -o ${NAME} ${SRCS}

--- a/usr/sedit/buffer.cmm
+++ b/usr/sedit/buffer.cmm
@@ -8,10 +8,11 @@ public char[][] textBuffer;
 
 void makeBuffer(){
   textBuffer = malloc(sizeof(void[]) * LINES);
-  for (int i = 0; i < LINES; i = i + 1){
-    textBuffer[i] = malloc(sizeof(char) * columns);
+  for(int i = 0; i < LINES; i = i + 1){
+    textBuffer[i] = malloc(sizeof(char) * (columns+1));
   }
-  clipboard = malloc(sizeof(char) * columns);
+  textBuffer[0][0] ='\0'; // ゴミデータが入らないようにする
+  clipboard = malloc(sizeof(char) * (columns+1));
 }
 
 public void freeBuffer(){

--- a/usr/sedit/buffer.cmm
+++ b/usr/sedit/buffer.cmm
@@ -12,100 +12,100 @@ public void bufferInit(){
 }
 
 // 新しい行追加
-public void insertLine(int row, int column){
+public void insertLine(int column, int row){
   if (lines >= LINES){
     return;
   }
 
   // 最後の行から現在の行の次までずらす
-  for(int i = lines-1; i > column; i = i - 1){
+  for(int i = lines-1; i > row; i = i - 1){
     strCpy(textBuffer[i+1], textBuffer[i]);
   }
 
   // 行の途中で挿入されたとき
-  if(row != BUFLEN-1){
-    int i=0, j=row;
-    while ((textBuffer[column+1][i]=textBuffer[column][j])!='\0') {
+  if(column != columns-1){
+    int i=0, j=column;
+    while ((textBuffer[row+1][i]=textBuffer[row][j])!='\0') {
       i = i + 1;
       j = j + 1;
     }
-    textBuffer[column][row]='\0';
+    textBuffer[row][column]='\0';
   } else {
-    textBuffer[column+1][0] = '\0';
+    textBuffer[row+1][0] = '\0';
   }
   lines = lines + 1;
 }
 
 // 文字挿入
-public void insertChar(char ch, int row, int column){
-  int length = strLen(textBuffer[column]); // 挿入前の文字列の長さ
+public void insertChar(char ch, int column, int row){
+  int length = strLen(textBuffer[row]); // 挿入前の文字列の長さ
   // 画面サイズを超える
-  if (length >= BUFLEN){
+  if (length >= columns){
     return;
   }
 
   // 挿入部分からずらす
-  for(int i = length; i >= row; i = i - 1){
-    textBuffer[column][i + 1] = textBuffer[column][i];
+  for(int i = length; i >= column; i = i - 1){
+    textBuffer[row][i + 1] = textBuffer[row][i];
   }
 
-  textBuffer[column][row] = ch;
+  textBuffer[row][column] = ch;
 }
 
 // 文字削除(カーソルの左の文字を削除)
-public void removeChar(int row, int column){
-  if(row == 0){
+public void removeChar(int column, int row){
+  if(column == 0){
     return;
   }
-  int length = strLen(textBuffer[column]);
+  int length = strLen(textBuffer[row]);
   // 後ろの文字を詰める
-  for(int i = row; i <= length; i = i + 1){
-    textBuffer[column][i-1] = textBuffer[column][i];
+  for(int i = column; i <= length; i = i + 1){
+    textBuffer[row][i-1] = textBuffer[row][i];
   }
 }
 
 // 行削除
-public void removeLine(int row, int column){
+public void removeLine(int column, int row){
   // その行の長さが０もしくはカーソル位置が左端なら後ろの行から詰める
-  if(column == 0){
+  if(row == 0){
     return;
   }
   // 後ろに文字がある
-  if(row == 0 && strLen(textBuffer[column]) != 0){
+  if(column == 0 && strLen(textBuffer[row]) != 0){
     int x = 0;
     // 文字を後ろからずらす
-    for(int i = strLen(textBuffer[column-1]); i < BUFLEN; i = i + 1){
-      textBuffer[column-1][i] = textBuffer[column][x];
-      if(textBuffer[column][x] == '\0'){
+    for(int i = strLen(textBuffer[row-1]); i < columns; i = i + 1){
+      textBuffer[row-1][i] = textBuffer[row][x];
+      if(textBuffer[row][x] == '\0'){
         break;
       }
       x = x + 1;
     }
     // 行の内容をクリア
-    textBuffer[column][0] = '\0';
+    textBuffer[row][0] = '\0';
   }
   // 行をずらす
-  for (int i = column; i < lines-1; i = i + 1){
+  for (int i = row; i < lines-1; i = i + 1){
     strCpy(textBuffer[i], textBuffer[i+1]);
   }
   textBuffer[lines-1][0] = '\0';
   lines = lines - 1;
 }
 
-public void cutLine(int row, int column){
-  int length = strLen(textBuffer[column]);
-  clipboard[length - row] = '\0';
-  for(int i = 0; i < length - row; i = i + 1){
-    clipboard[i] = textBuffer[column][row + i];
+public void cutLine(int column, int row){
+  int length = strLen(textBuffer[row]);
+  clipboard[length - column] = '\0';
+  for(int i = 0; i < length - column; i = i + 1){
+    clipboard[i] = textBuffer[row][column + i];
   }
-  textBuffer[column][row] = '\0';
+  textBuffer[row][column] = '\0';
 }
 
-public void pasteLine(int row, int column){
+public void pasteLine(int column, int row){
   for(int i = 0; ; i=i+1){
-    if(clipboard[i] == '\0' || row + i == BUFLEN){
+    if(clipboard[i] == '\0' || column + i == columns){
       break;
     }
-    insertChar(clipboard[i], row+i, column);
+    insertChar(clipboard[i], column+i, row);
   }
 }

--- a/usr/sedit/buffer.cmm
+++ b/usr/sedit/buffer.cmm
@@ -6,7 +6,7 @@
 char[] clipboard;
 public char[][] textBuffer;
 
-void makeBuffer(int columns){
+void makeBuffer(){
   int maxSize = 150 * 81;   // 横幅の最大サイズが８０と仮定
   maxLine = maxSize / (columns+1); // 割り当てたヒープ領域をできるだけ使うようにする
   textBuffer = malloc(sizeof(void[]) * maxLine);
@@ -15,14 +15,6 @@ void makeBuffer(int columns){
   }
   textBuffer[0][0] ='\0'; // ゴミデータが入らないようにする
   clipboard = malloc(sizeof(char) * (columns+1));
-}
-
-public void freeBuffer(){
-  for (int i = 0; i < maxLine; i = i + 1){
-    free(textBuffer[i]);
-  }
-  free(textBuffer);
-  free(clipboard);
 }
 
 // 初期化

--- a/usr/sedit/buffer.cmm
+++ b/usr/sedit/buffer.cmm
@@ -12,8 +12,8 @@ void makeBuffer(){
   textBuffer = malloc(sizeof(void[]) * maxLine);
   for(int i = 0; i < maxLine; i = i + 1){
     textBuffer[i] = malloc(sizeof(char) * (columns+1));
+    textBuffer[i][0] ='\0'; // ゴミデータが入らないようにする
   }
-  textBuffer[0][0] ='\0'; // ゴミデータが入らないようにする
   clipboard = malloc(sizeof(char) * (columns+1));
 }
 

--- a/usr/sedit/buffer.cmm
+++ b/usr/sedit/buffer.cmm
@@ -12,8 +12,8 @@ void makeBuffer(){
   textBuffer = malloc(sizeof(void[]) * maxLine);
   for(int i = 0; i < maxLine; i = i + 1){
     textBuffer[i] = malloc(sizeof(char) * (columns+1));
-    textBuffer[i][0] ='\0'; // ゴミデータが入らないようにする
   }
+  textBuffer[0][0] ='\0'; // ゴミデータが入らないようにする
   clipboard = malloc(sizeof(char) * (columns+1));
 }
 

--- a/usr/sedit/buffer.cmm
+++ b/usr/sedit/buffer.cmm
@@ -6,9 +6,11 @@
 char[] clipboard;
 public char[][] textBuffer;
 
-void makeBuffer(){
-  textBuffer = malloc(sizeof(void[]) * LINES);
-  for(int i = 0; i < LINES; i = i + 1){
+void makeBuffer(int columns){
+  int maxSize = 150 * 81;   // 横幅の最大サイズが８０と仮定
+  maxLine = maxSize / (columns+1); // 割り当てたヒープ領域をできるだけ使うようにする
+  textBuffer = malloc(sizeof(void[]) * maxLine);
+  for(int i = 0; i < maxLine; i = i + 1){
     textBuffer[i] = malloc(sizeof(char) * (columns+1));
   }
   textBuffer[0][0] ='\0'; // ゴミデータが入らないようにする
@@ -16,7 +18,7 @@ void makeBuffer(){
 }
 
 public void freeBuffer(){
-  for (int i = 0; i < LINES; i = i + 1){
+  for (int i = 0; i < maxLine; i = i + 1){
     free(textBuffer[i]);
   }
   free(textBuffer);
@@ -31,7 +33,7 @@ public void bufferInit(){
 
 // 新しい行追加
 public void insertLine(int column, int row){
-  if (lines >= LINES){
+  if (lines >= maxLine){
     return;
   }
 

--- a/usr/sedit/buffer.cmm
+++ b/usr/sedit/buffer.cmm
@@ -3,11 +3,28 @@
 #include <string.hmm>
 #include "buffer.hmm"
 
-public char[][] textBuffer = array(LINES, BUFLEN+1); // 書き込まれた文字保存用
-char[] clipboard = array(BUFLEN+1);
+char[] clipboard;
+public char[][] textBuffer;
+
+void makeBuffer(){
+  textBuffer = malloc(sizeof(void[]) * LINES);
+  for (int i = 0; i < LINES; i = i + 1){
+    textBuffer[i] = malloc(sizeof(char) * columns);
+  }
+  clipboard = malloc(sizeof(char) * columns);
+}
+
+public void freeBuffer(){
+  for (int i = 0; i < LINES; i = i + 1){
+    free(textBuffer[i]);
+  }
+  free(textBuffer);
+  free(clipboard);
+}
 
 // 初期化
 public void bufferInit(){
+  makeBuffer();
   lines = 1;  // 初期状態で1行存在
 }
 

--- a/usr/sedit/buffer.hmm
+++ b/usr/sedit/buffer.hmm
@@ -1,8 +1,9 @@
-vpublic int lines;   //合計
+public int lines;   //合計
+public int columns
 public int maxLine;
 public char[][] textBuffer;
 
-public void freeBuffer();
+public void makeBuffer();
 public void bufferInit();
 public void insertLine(int column, int row);
 public void insertChar(char c, int column, int row);

--- a/usr/sedit/buffer.hmm
+++ b/usr/sedit/buffer.hmm
@@ -6,9 +6,9 @@ public char[][] textBuffer;
 
 public void freeBuffer();
 public void bufferInit();
-public void insertLine(int row, int column);
-public void insertChar(char c, int row, int column);
-public void removeChar(int row, int column);
-public void removeLine(int row, int column);
-public void cutLine(int row, int column);
-public void pasteLine(int row, int column);
+public void insertLine(int column, int row);
+public void insertChar(char c, int column, int row);
+public void removeChar(int column, int row);
+public void removeLine(int column, int row);
+public void cutLine(int column, int row);
+public void pasteLine(int column, int row);

--- a/usr/sedit/buffer.hmm
+++ b/usr/sedit/buffer.hmm
@@ -2,6 +2,7 @@
 #define BUFLEN 80
 
 public int lines;   //合計
+public int columns;
 public char[][] textBuffer;
 
 public void bufferInit();

--- a/usr/sedit/buffer.hmm
+++ b/usr/sedit/buffer.hmm
@@ -1,7 +1,5 @@
-#define LINES 150
-
-public int lines;   //合計
-public int columns;
+vpublic int lines;   //合計
+public int maxLine;
 public char[][] textBuffer;
 
 public void freeBuffer();

--- a/usr/sedit/buffer.hmm
+++ b/usr/sedit/buffer.hmm
@@ -1,5 +1,4 @@
 #define LINES 150
-#define BUFLEN 80
 
 public int lines;   //合計
 public int columns;

--- a/usr/sedit/buffer.hmm
+++ b/usr/sedit/buffer.hmm
@@ -4,6 +4,7 @@ public int lines;   //合計
 public int columns;
 public char[][] textBuffer;
 
+public void freeBuffer();
 public void bufferInit();
 public void insertLine(int row, int column);
 public void insertChar(char c, int row, int column);

--- a/usr/sedit/screen.cmm
+++ b/usr/sedit/screen.cmm
@@ -28,16 +28,16 @@ public void moveCursor(){
 // 行末に移動
 public void moveToEndOfLine(){
   c.x = strLen(textBuffer[current]);
-  if(c.x >= ROWS){
-    c.x = ROWS-1;
+  if(c.x >= columns){
+    c.x = columns-1;
   }
 }
 
 // デバッグ用
 public void printBufferInfo(){
-  printf("\x1b[%d;%dH", COLUMNS, 1);
+  printf("\x1b[%d;%dH", rows, 1);
   printf("\r\x1b[2K");
-  printf("(%d, %d), current:%d, top:%d, lines:%d, length:%d", c.x, c.y, current, top, lines, strLen(textBuffer[current]));
+  printf("(%d, %d), current:%d, top:%d, lines:%d, length:%d, size:%d, %d", c.x, c.y, current, top, lines, strLen(textBuffer[current]), columns, rows);
   moveCursor();
 }
 
@@ -45,7 +45,7 @@ public void printBufferInfo(){
 public void displayAll(){
   // 画面クリア
   clear();
-  int end = COLUMNS - 1;
+  int end = rows - 1;
   if(lines-1 - top < end){
     end = lines-1 - top;
   }
@@ -70,7 +70,7 @@ public void displayAllFromCursor(){
 
   // 次の行から表示
   int start = current + 1;
-  int end = start + COLUMNS - c.y - 2;
+  int end = start + rows - c.y - 2;
   if(lines <= end){
     end = lines - 1;
   }
@@ -102,8 +102,8 @@ public void moveRight(){
   c.x = c.x + 1;
 
   // 最大数を超えない
-  if(c.x >= ROWS){
-    c.x = ROWS - 1;
+  if(c.x >= columns){
+    c.x = columns - 1;
   } else if(c.x > strLen(textBuffer[current])){
     c.x = strLen(textBuffer[current]);
   }
@@ -129,10 +129,10 @@ public void moveDown(){
   if(c.x > strLen(textBuffer[current])){
     moveToEndOfLine();
   }
-  if(c.y == COLUMNS){
-    c.y = COLUMNS - 1;
+  if(c.y == rows){
+    c.y = rows - 1;
     // 下に表示可能な部分があれば一番上の行を更新
-    if(top + (COLUMNS-1) < lines-1){
+    if(top + (rows-1) < lines-1){
       top = top + 1;
     }
   }

--- a/usr/sedit/screen.hmm
+++ b/usr/sedit/screen.hmm
@@ -4,6 +4,7 @@ struct cursor{
 };
 
 public int current;
+public int rows;
 public cursor c;
 public int top;
 

--- a/usr/sedit/screen.hmm
+++ b/usr/sedit/screen.hmm
@@ -1,6 +1,3 @@
-#define ROWS 80
-#define COLUMNS 24
-
 struct cursor{
   int x;
   int y;

--- a/usr/sedit/sedit.cmm
+++ b/usr/sedit/sedit.cmm
@@ -208,7 +208,6 @@ public int main(int argc, char[][] argv){
 
   // save
   saveFile(fileName);
-  freeBuffer();
   printf("\x1b[J\r\n");
 
   return 0;

--- a/usr/sedit/sedit.cmm
+++ b/usr/sedit/sedit.cmm
@@ -26,7 +26,7 @@ void keyboard(char key){
       }
     }else if (key == 'B'){  // down
       moveDown();
-      if (c.y == COLUMNS-1){
+      if (c.y == rows-1){
         displayAll();
       }
     } else if (key == 'C'){ // right
@@ -73,12 +73,12 @@ void keyboard(char key){
     insertLine(c.x, current);
     moveDown();
     // カーソルが画面の一番下なら全画面更新
-    if (c.y == COLUMNS-1){
+    if (c.y == rows-1){
       displayAll();
     } else {
       c.x = oldX;
       // 画面右端にカーソルがあった場合は先に移動
-      if(c.x == ROWS-1){
+      if(c.x == columns-1){
         moveCursor();
       }
       clearFromCursor();

--- a/usr/sedit/sedit.cmm
+++ b/usr/sedit/sedit.cmm
@@ -4,11 +4,39 @@
 #include <syslib.hmm>                    // TaC版は一部のシステムコールを使う
 #include "buffer.hmm"
 #include "screen.hmm"
+#include <ctype.hmm>
 
 #define CTRL(c) chr(0x1f & ord(c))
 
-char[] kbdBuf = array(BUFLEN);            // 入力用
+char[] kbdBuf = array(80);            // 入力用
 boolean isEsc= false;
+int orgMode, rawMode;
+
+void init(){
+  printf("\x1b?s\n");
+  char ch;
+  int num = 0;
+  ttyCtl(TTYCTL_SETMODE, rawMode);
+  while(true){
+    ttyRead(kbdBuf, 1);
+    ch = kbdBuf[0];
+
+    if(ch == 's'){
+      rows = num;
+      break;
+    } else if(ch == ','){
+      columns = num;
+      num = 0;
+    } else {
+      if(isDigit(ch)){
+        num = num*10 + ord(ch)-48;
+      }
+    }
+  }
+  ttyCtl(TTYCTL_SETMODE, orgMode);
+  screenInit();
+  bufferInit();
+}
 
 // 入力文字の処理
 void keyboard(char key){
@@ -159,15 +187,13 @@ public int main(int argc, char[][] argv){
     fprintf(stderr, "Usage, %s <filename>\n", argv[0]);
     return 1;
   }
-  bufferInit();
-  screenInit();
-
   char[] fileName = argv[1];
 
   char ch;
-  int orgMode = ttyCtl(TTYCTL_GETMODE, 0);     // 普通のモード
-  int rawMode = orgMode & ~TTYCTL_MODE_ECHO & ~TTYCTL_MODE_COOKED;  // １文字入力
+  orgMode = ttyCtl(TTYCTL_GETMODE, 0);     // 普通のモード
+  rawMode = orgMode & ~TTYCTL_MODE_ECHO & ~TTYCTL_MODE_COOKED;  // １文字入力
 
+  init();
   stdout.buf = null;  // stdoutのバッファリングを禁止
   clear();
 
@@ -190,6 +216,7 @@ public int main(int argc, char[][] argv){
 
   // save
   saveFile(fileName);
+  freeBuffer();
   printf("\x1b[J\r\n");
 
   return 0;

--- a/usr/sedit/sedit.cmm
+++ b/usr/sedit/sedit.cmm
@@ -65,7 +65,7 @@ void keyboard(char key){
     isEsc = false;
     moveCursor();
     return;
-  } else if (key == '\x7f'){    // del
+  } else if (key == '\x7f' || key == '\x08'){    // del or bs
     // 行の左端
     if(c.x == 0){
       removeLine(c.x, current);

--- a/usr/sedit/sedit.cmm
+++ b/usr/sedit/sedit.cmm
@@ -83,10 +83,7 @@ void keyboard(char key){
     moveCursor();
     return;
   } else if(key == '\x09'){ // tab
-    int move = c.x % 4;
-    if(move == 0){
-      move = 4;
-    }
+    int move = 4 - c.x % 4;
     for(int i = 0; i < move; i=i+1){
       insertChar(' ', c.x, current);
     }

--- a/usr/sedit/sedit.cmm
+++ b/usr/sedit/sedit.cmm
@@ -176,7 +176,7 @@ void saveFile(char[] fileName) {
 public int main(int argc, char[][] argv){
   if(argc < 2 || 3 < argc || (argc == 3 && strCmp(argv[1], "-t") != 0)){
     fprintf(stderr, "Usage: %s [-t] <filename> \n", argv[0]);
-    fprintf(stderr, "   -t: Not use TeC terminal \n");
+    fprintf(stderr, "   -t: Not using a terminal for TeC \n");
     return 1;
   }
   char[] fileName = argv[argc-1];

--- a/usr/sedit/sedit.cmm
+++ b/usr/sedit/sedit.cmm
@@ -8,7 +8,7 @@
 
 #define CTRL(c) chr(0x1f & ord(c))
 
-char[] kbdBuf = array(80);            // 入力用
+char[] kbdBuf = array(1);            // 入力用
 boolean isEsc= false;
 int orgMode, rawMode;
 

--- a/usr/sedit/sedit.cmm
+++ b/usr/sedit/sedit.cmm
@@ -131,7 +131,6 @@ void keyboard(char key){
   }
   insertChar(key, c.x, current);
   displayLineFromCursor();
-
   moveRight();
   moveCursor();
 
@@ -143,10 +142,7 @@ void loadFile(char[] fileName) {
   FILE fp;
   char ch;
   fp = fopen(fileName, "r"); // ファイルを開く
-  if (fp == null) {
-    perror(fileName);
-    printf("\x1b[2J\x1b[H");
-  } else {
+  if (fp != null) {
     while(!feof(fp)) {
       ch = fgetc(fp);
       keyboard(ch);
@@ -193,7 +189,6 @@ public int main(int argc, char[][] argv){
   init();
   stdout.buf = null;  // stdoutのバッファリングを禁止
   clear();
-
   // ファイル読み込み
   loadFile(fileName);
 

--- a/usr/sedit/sedit.cmm
+++ b/usr/sedit/sedit.cmm
@@ -29,7 +29,7 @@ void init(){
       num = 0;
     } else {
       if(isDigit(ch)){
-        num = num*10 + ord(ch)-48;
+        num = num*10 + ord(ch) - ord('0');
       }
     }
   }

--- a/usr/sedit/sedit.cmm
+++ b/usr/sedit/sedit.cmm
@@ -34,8 +34,6 @@ void init(){
     }
   }
   ttyCtl(TTYCTL_SETMODE, orgMode);
-  screenInit();
-  bufferInit();
 }
 
 // 入力文字の処理
@@ -176,17 +174,26 @@ void saveFile(char[] fileName) {
 }
 
 public int main(int argc, char[][] argv){
-  if(argc!=2){
-    fprintf(stderr, "Usage, %s <filename>\n", argv[0]);
+  if(argc < 2 || 3 < argc || (argc == 3 && strCmp(argv[1], "-t") != 0)){
+    fprintf(stderr, "Usage: %s [-t] <filename> \n", argv[0]);
+    fprintf(stderr, "   -t: Not use TeC terminal \n");
     return 1;
   }
-  char[] fileName = argv[1];
+  char[] fileName = argv[argc-1];
 
   char ch;
   orgMode = ttyCtl(TTYCTL_GETMODE, 0);     // 普通のモード
   rawMode = orgMode & ~TTYCTL_MODE_ECHO & ~TTYCTL_MODE_COOKED;  // １文字入力
 
-  init();
+  if(argc == 2){
+    init();
+  } else {
+    columns = 80;
+    rows = 24;
+  }
+  screenInit();
+  bufferInit();
+
   stdout.buf = null;  // stdoutのバッファリングを禁止
   clear();
   // ファイル読み込み


### PR DESCRIPTION
・sedit 実行時に画面サイズを受け取るエスケープシーケンスを送信する機能を追加
・バッファの動的割り当てを行うように変更
・バッファの横幅を決めるために必要だったため， buffer.hmm が画面の横幅の大きさを持つように変更
・row と column の意味合いが逆だったのを変更
・textBufferの最大サイズを横幅に依存させるように
・タブの入力サイズがおかしかったのを修正